### PR TITLE
use an envvar to change the default endpoint

### DIFF
--- a/expvar.go
+++ b/expvar.go
@@ -413,8 +413,14 @@ func memstats() interface{} {
 	return *stats
 }
 
+const defaultEndpoint = "/debug/vars"
+
 func init() {
-	http.HandleFunc("/debug/vars", expvarHandler)
+	ep := os.Getenv("EXPVAR_ENDPOINT")
+	if ep == "" {
+		ep = defaultEndpoint
+	}
+	http.HandleFunc(ep, expvarHandler)
 	Publish("cmdline", Func(cmdline))
 	Publish("memstats", Func(memstats))
 }


### PR DESCRIPTION
a fix for #1 

Have the init function check if `EXPVAR_ENDPOINT` is set and use that instead of the default `/debug/vars`
This gives the option to resolve a conflict and code depending on the default behaviour won't break.
